### PR TITLE
Do not break commands that perform STDOUT interaction (such as the Googl...

### DIFF
--- a/fullscreenhack.c
+++ b/fullscreenhack.c
@@ -25,7 +25,6 @@ void __attribute__ ((constructor)) load(void);
 // Called when the library is loaded and before dlopen() returns
 void load(void)
 {
-    fprintf(stderr, "fullscreen hack loaded...\n");
 }
 
 int choose_screen(Display *display, XineramaScreenInfo *screens, 


### PR DESCRIPTION
...e Chrome wrapper [google-chrome]) by not displaying any banner when the library is loaded

Currently, Google Chrome cannot be launched via the google-chrome wrapper script when the fullscrennhack is enabled as setting LD_PRELOAD causes all commands invoked from the google-chrome shell script to emit the "fullscreen hack loaded..." banner, which interferes with commands that perform screen output.

This change corrects this by getting rid of the banner.
