### PR TITLE
Wishlist: Prevent exiting fullscreen mode when pointer exits window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+*.so
+tester

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BITS=32
+BITS=64
 
 all: tester libfullscreenhack.so
 
@@ -14,6 +14,9 @@ test: all
 	./tester
 	echo running with the hack...
 	LD_PRELOAD=./libfullscreenhack.so ./tester
+
+fftest: all
+	LD_PRELOAD=`pwd`/libfullscreenhack.so firefox 'http://www.youtube.com'
 
 clean:
 	rm -f *.o *.so tester

--- a/README
+++ b/README
@@ -8,7 +8,9 @@ Why
 Flash plugin incorrectly determines the fullscreen resolution when 
 using nvidia twinview. The result is that fullscreen windows fill 
 the primary monitor, but the video gets scaled as if the primary 
-monitor had the resolution of the total display area.
+monitor had the resolution of the total display area. Even worse,
+Flash has a nasty habit of dropping out of fullscreen mode when
+you try to do anything on the other monitor.
 
 How
 ---
@@ -19,6 +21,10 @@ If XGetGeometry would return the size of the root window, the patch
 causes it to instead return the size of a single monitor.
 
 The monitor sizes sent are now based on Xinerama.
+
+Fullscreen mode is no longer dropped when Flash loses focus by
+simply masking out PropertyChange X events, stopping the
+behaviour entirely.
 
 
 Config
@@ -46,6 +52,10 @@ Test it:
 make test
 
 This runs the tester app with and without the patch to verify that it works.
+
+make fftest
+
+This runs Firefox with the patch enabled so Flash can be tested directly.
 
 Install it:
 

--- a/fullscreenhack.c
+++ b/fullscreenhack.c
@@ -1,15 +1,19 @@
 // fullscreenhack.c
 // Alistair Buxton <a.j.buxton@gmail.com>
+// extended by Steve Purchase <steve@t220.com>
 
 #include <dlfcn.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <X11/Xlib.h>
 #include <X11/extensions/Xinerama.h>
 
-typedef Status (*xgg_func)(Display *, Drawable, Window *, 
-				int *, int *, unsigned int *, 
-				unsigned int *, unsigned int *, 
+typedef Status (*xgg_func)(Display *, Drawable, Window *,
+				int *, int *, unsigned int *,
+				unsigned int *, unsigned int *,
 				unsigned int *);
+
+typedef int (*xselectinput_func)(Display*, Window, long);
 
 typedef XineramaScreenInfo * (*xsi_func)(Display*,int*);
 
@@ -28,7 +32,7 @@ void load(void)
     fprintf(stderr, "fullscreen hack loaded...\n");
 }
 
-int choose_screen(Display *display, XineramaScreenInfo *screens, 
+int choose_screen(Display *display, XineramaScreenInfo *screens,
                     int n_screens, void *xlib_handle)
 {
     const char *s = getenv("FLASH_FULLSCREEN_DISPLAY");
@@ -37,21 +41,20 @@ int choose_screen(Display *display, XineramaScreenInfo *screens,
     Window root = RootWindow(display, DefaultScreen(display));
     int x, y, wx, wy, n;
     unsigned int mask;
-    Bool result;
     if (s != NULL) {
         int w = strtol(s, &e, 0);
         if (e != NULL && *e == 0 && w >= 0 && w < n_screens)
             return w;
 	}
     xqp_func xqp = dlsym(xlib_handle, "XQueryPointer");
-    result = xqp(display, root, &a, &b, &x, &y, &wx, &wy, &mask);
+    xqp(display, root, &a, &b, &x, &y, &wx, &wy, &mask);
     fprintf(stderr, "pointer: %dx%d\n", x, y);
     for(n=0;n<n_screens;n++) {
-        fprintf(stderr, "screen %d, %dx%d+%d+%d\n", n, screens[n].width, 
+        fprintf(stderr, "screen %d, %dx%d+%d+%d\n", n, screens[n].width,
                 screens[n].height, screens[n].x_org, screens[n].y_org);
-        if (x >= screens[n].x_org && 
+        if (x >= screens[n].x_org &&
             x < (screens[n].x_org + screens[n].width) &&
-            y >= screens[n].y_org && 
+            y >= screens[n].y_org &&
             y < (screens[n].y_org + screens[n].height)) {
             fprintf(stderr, "match found\n");
             return n;
@@ -60,20 +63,20 @@ int choose_screen(Display *display, XineramaScreenInfo *screens,
     return 0;
 }
 
-Status XGetGeometry(Display *display, Drawable d, Window *root_return, 
-            int *x_return, int *y_return, 
-            unsigned int *width_return, 
-            unsigned int *height_return, 
-            unsigned int *border_width_return, 
+Status XGetGeometry(Display *display, Drawable d, Window *root_return,
+            int *x_return, int *y_return,
+            unsigned int *width_return,
+            unsigned int *height_return,
+            unsigned int *border_width_return,
             unsigned int *depth_return)
 {
     void *xlib_handle;
     Status s;
     xlib_handle = dlopen("libX11.so", RTLD_LAZY);
     xgg_func xgg = dlsym(xlib_handle, "XGetGeometry");
-    s = xgg(display, d, root_return, 
-                x_return, y_return, 
-                width_return, height_return, 
+    s = xgg(display, d, root_return,
+                x_return, y_return,
+                width_return, height_return,
                 border_width_return, depth_return);
 
     if (d == RootWindow(display, DefaultScreen(display))) {
@@ -96,4 +99,15 @@ Status XGetGeometry(Display *display, Drawable d, Window *root_return,
 
 }
 
+int XSelectInput(Display* display, Window window, long event_mask)
+{
+    void *xlib_handle;
+    xlib_handle = dlopen("libX11.so", RTLD_LAZY);
+    xselectinput_func fn = dlsym(xlib_handle, "XSelectInput");
 
+    // Mask out PropertyChange events so Flash doesn't realise
+    // the pointer/focus has left the window.
+    event_mask &= ~PropertyChangeMask;
+
+    return fn(display, window, event_mask);
+}


### PR DESCRIPTION
Normally fullscreen mode is cancelled when the pointer leaves the window - I find this very frustrating. It seems that hacking the Flash binary is one way to disable this behaviour . Sadly this needs to be re-hacked every time the binary is updated so is not a good solution.

I wonder if it is possible to achieve the same effect via an extension to this LD_PRELOAD?  Perhaps remove LeaveWindow events? Maybe only when in fullscreen mode? Not sure, but it would seem like there's a chance of making this work.

I'll have play with this eventually and see if I can make it work but if anyone can achieve it quickly and easily then great :)
